### PR TITLE
Update were-just-normal-repositories.json

### DIFF
--- a/branch-rulesets/were-just-normal-repositories.json
+++ b/branch-rulesets/were-just-normal-repositories.json
@@ -30,7 +30,7 @@
             "parameters": {
                 "required_status_checks": [
                     {
-                        "context": "`status check context name`",
+                        "context": "status check context name",
                         "integration_id": `integration ID that this status check must originate from.`
                     }
                 ],

--- a/branch-rulesets/were-just-normal-repositories.json
+++ b/branch-rulesets/were-just-normal-repositories.json
@@ -30,7 +30,7 @@
             "parameters": {
                 "required_status_checks": [
                     {
-                        "context": `status check context name`",
+                        "context": "`status check context name`",
                         "integration_id": `integration ID that this status check must originate from.`
                     }
                 ],

--- a/branch-rulesets/were-just-normal-repositories.json
+++ b/branch-rulesets/were-just-normal-repositories.json
@@ -31,7 +31,7 @@
                 "required_status_checks": [
                     {
                         "context": "status check context name",
-                        "integration_id": `integration ID that this status check must originate from.`
+                        "integration_id": integration ID that this status check must originate from.
                     }
                 ],
                 "strict_required_status_checks_policy": false


### PR DESCRIPTION
Add a quote to the value of the `"context":` key. It may had been left out on purpose but closing just in case. I'm not sure if I need to add quotes around the integration id but figured we could at least close the double quotes on this. 